### PR TITLE
ignore tags because they are inherited from subscription or resource_…

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -36,6 +36,12 @@ resource "azurerm_resource_group" "this" {
   name     = "rg-network-${var.application_details.name}-${var.application_details.environment}"
   location = var.application_details.location
   tags     = try(var.tags, null)
+
+  # tags are typically provided by policies on Subscriptions or ResourceGroups and will be overwritten by
+  # DeployIfNotExists policies this results in conflicts to each other
+  lifecycle {
+    ignore_changes = [ tags ]
+  }
 }
 
 module "network" {
@@ -94,6 +100,10 @@ resource "azurerm_route_table" "this" {
   tags                          = try(var.tags, null)
 
   depends_on = [azurerm_resource_group.this]
+
+  lifecycle {
+    ignore_changes = [ tags ]
+  }
 }
 
 
@@ -197,6 +207,10 @@ resource "azurerm_network_security_group" "this" {
   resource_group_name = azurerm_resource_group.this.name
 
   tags = try(var.tags, null)
+
+  lifecycle {
+    ignore_changes = [ tags ]
+  }
 }
 
 # data structure for network security group association

--- a/modules/terraform-azurerm-network/main.tf
+++ b/modules/terraform-azurerm-network/main.tf
@@ -22,6 +22,10 @@ resource "azurerm_virtual_network" "this" {
   edge_zone               = var.network.edge_zone
   flow_timeout_in_minutes = var.network.flow_timeout_in_minutes
   tags                    = try(var.tags, null)
+
+  lifecycle {
+    ignore_changes = [ tags ]
+  }
 }
 
 ###############################


### PR DESCRIPTION
## Pull Request Type - Chose one of the listed items and delete the other.
- **Chore** (All changes that do not affect the program's operation.)

## Description - Please provide a brief description of the changes made in this pull request.
- Tag inheritance will be provided via policies and CAF module on subscription or resource_group level. This will be a conflict with setting tags on resources via terraform. Solution is to use ignore_changes = [tags] or to inherit tags via terraform and data.azurerm_subscription.<current>.tags.

## Related Issue(s) - Please list all related issue(s) here using github key words for automatically closing them.
- currently no listed